### PR TITLE
Improve Serial Monitor with larger size, autoscroll toggle, copy/download

### DIFF
--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -491,7 +491,7 @@
                                 <input type="checkbox" v-model="terminalAutoscroll" style="width: 16px; height: 16px;" />
                                 {{ t.terminal.autoscroll }}
                             </label>
-                            <button class="btn btn-sm btn-info" @click="copyTerminal">{{ t.terminal.copy }}</button>
+                            <button class="btn btn-sm btn-info" @click="copyTerminal($event)">{{ t.terminal.copy }}</button>
                             <button class="btn btn-sm btn-info" @click="downloadTerminal">{{ t.terminal.download }}</button>
                             <button class="btn btn-sm btn-danger" @click="clearTerminal">{{ t.terminal.clear }}</button>
                         </div>
@@ -1513,17 +1513,42 @@
                 sendQuickCmd(cmd) {
                     this.writeToStream(cmd);
                 },
-                copyTerminal() {
+                copyTerminal(event) {
                     const terminal = document.getElementById('terminal');
                     if (terminal) {
                         const text = terminal.innerText;
-                        navigator.clipboard.writeText(text).then(() => {
-                            const btn = event.target;
-                            const originalText = btn.textContent;
-                            btn.textContent = this.t.terminal.copied;
-                            setTimeout(() => { btn.textContent = originalText; }, 1500);
-                        });
+                        const btn = event.target;
+                        const originalText = btn.textContent;
+
+                        // Try modern clipboard API first, fallback to execCommand
+                        if (navigator.clipboard && navigator.clipboard.writeText) {
+                            navigator.clipboard.writeText(text).then(() => {
+                                btn.textContent = this.t.terminal.copied;
+                                setTimeout(() => { btn.textContent = originalText; }, 1500);
+                            }).catch(() => {
+                                this.fallbackCopy(text, btn, originalText);
+                            });
+                        } else {
+                            this.fallbackCopy(text, btn, originalText);
+                        }
                     }
+                },
+                fallbackCopy(text, btn, originalText) {
+                    // Fallback for non-HTTPS or older browsers
+                    const textarea = document.createElement('textarea');
+                    textarea.value = text;
+                    textarea.style.position = 'fixed';
+                    textarea.style.opacity = '0';
+                    document.body.appendChild(textarea);
+                    textarea.select();
+                    try {
+                        document.execCommand('copy');
+                        btn.textContent = this.t.terminal.copied;
+                        setTimeout(() => { btn.textContent = originalText; }, 1500);
+                    } catch (e) {
+                        console.error('Copy failed:', e);
+                    }
+                    document.body.removeChild(textarea);
                 },
                 downloadTerminal() {
                     const terminal = document.getElementById('terminal');


### PR DESCRIPTION
## Summary
- Increase default terminal height from 200px to 400px
- Make terminal resizable with drag handle (min 150px, max 80vh)
- Add Autoscroll checkbox toggle (enabled by default)
- Add Copy button to copy terminal content to clipboard
- Add Download button to save terminal log as timestamped .log file
- Add Clear button to clear terminal output
- Add translations for EN/FR/DE

## Test plan
- [x] Verify terminal is larger by default
- [x] Verify terminal can be resized by dragging the bottom edge
- [x] Test Autoscroll toggle - unchecking should stop auto-scrolling
- [x] Test Copy button - should copy terminal content to clipboard
- [x] Test Download button - should download a .log file with timestamp
- [x] Test Clear button - should clear terminal content
- [x] Test translations in FR and DE locales

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)