### PR TITLE
Refactor: Extract translations to separate JSON files

### DIFF
--- a/custom_components/emontx_config/frontend/i18n/de.json
+++ b/custom_components/emontx_config/frontend/i18n/de.json
@@ -1,8 +1,6 @@
 {
     "title": "emonPi/Tx Konfiguration",
     "subtitle": "Konfigurieren Sie Ihr OpenEnergyMonitor emonPi/Tx Gerät über die ESP32 Serielle Brücke",
-    "haStatus": "Home Assistant",
-    "deviceStatus": "emonPi/Tx",
     "deviceSelector": "Gerät",
     "connected": "Verbunden",
     "disconnected": "Getrennt",

--- a/custom_components/emontx_config/frontend/i18n/en.json
+++ b/custom_components/emontx_config/frontend/i18n/en.json
@@ -1,8 +1,6 @@
 {
     "title": "emonPi/Tx Configuration",
     "subtitle": "Configure your OpenEnergyMonitor emonPi/Tx device via ESP32 serial bridge",
-    "haStatus": "Home Assistant",
-    "deviceStatus": "emonPi/Tx",
     "deviceSelector": "Device",
     "connected": "Connected",
     "disconnected": "Disconnected",

--- a/custom_components/emontx_config/frontend/i18n/fr.json
+++ b/custom_components/emontx_config/frontend/i18n/fr.json
@@ -1,8 +1,6 @@
 {
     "title": "Configuration emonPi/Tx",
     "subtitle": "Configurez votre appareil OpenEnergyMonitor emonPi/Tx via le pont série ESP32",
-    "haStatus": "Home Assistant",
-    "deviceStatus": "emonPi/Tx",
     "deviceSelector": "Appareil",
     "connected": "Connecté",
     "disconnected": "Déconnecté",

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -280,11 +280,11 @@
         <div class="status-bar">
             <div class="status-item">
                 <div :class="['status-dot', wsConnected ? 'connected' : 'disconnected']"></div>
-                <span>{{ t.haStatus }}: <strong>{{ wsConnected ? t.connected : t.disconnected }}</strong></span>
+                <span>Home Assistant: <strong>{{ wsConnected ? t.connected : t.disconnected }}</strong></span>
             </div>
             <div class="status-item">
                 <div :class="['status-dot', emontxConnected ? 'connected' : 'disconnected']"></div>
-                <span>{{ t.deviceStatus }}: <strong>{{ emontxConnected ? t.connected : t.unknown }}</strong></span>
+                <span>emonPi/Tx: <strong>{{ emontxConnected ? t.connected : t.unknown }}</strong></span>
             </div>
             <div class="status-item" style="margin-left: auto;">
                 <label style="margin-right: 8px;">{{ t.deviceSelector }}:</label>


### PR DESCRIPTION
## Summary
- Create `i18n/` folder with separate JSON files for each language (en.json, fr.json, de.json)
- Load translations dynamically via fetch() at runtime
- Reduce panel.html from ~1600 to 1413 lines (~12% reduction)

## Benefits
- Easier to add new languages (just add a new JSON file)
- Translators can work on JSON files without touching main code
- Cleaner separation of concerns
- Better maintainability

## Test plan
- [x] Verify panel loads correctly with English (default)
- [x] Change Home Assistant language to French, verify French translations load
- [x] Change Home Assistant language to German, verify German translations load
- [x] Verify fallback to English works if translation file is missing
- [x] Check browser console for "Translations loaded for:" message

## File structure
```
frontend/
  panel.html
  i18n/
    en.json
    fr.json
    de.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)