### PR TITLE
Refactor i18n: Extract translations to separate JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # emonPi/Tx Configuration for Home Assistant
 
+[![GitHub Release](https://img.shields.io/github/v/release/FredM67/ha-emon-config)](https://github.com/FredM67/ha-emon-config/releases)
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=FredM67&repository=ha-emon-config&category=integration)
 
 A Home Assistant integration that provides a web-based configuration interface for OpenEnergyMonitor emonPi/Tx devices connected via an ESP32 serial bridge running ESPHome.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,19 @@ A Home Assistant integration that provides a web-based configuration interface f
 ## Features
 
 - **Device Configuration**: Full configuration interface for CT calibration, voltage calibration, radio settings, and more
+- **Multi-device Support**: Switch between multiple emonPi/Tx devices from a dropdown selector
 - **Serial Terminal**: Send commands and receive responses from your emonTx device
+  - Autoscroll toggle, copy to clipboard, download log, clear terminal
+  - Resizable terminal window
+  - Quick command buttons for common operations
 - **Live Data Display**: View real-time power and energy readings from all channels
+  - Data grouped by type (Voltage, Power, Energy, Temperature, Pulse)
+  - Inactive channels shown with strikethrough indicator
 - **Zero Energy**: Reset energy counters with confirmation countdown (matching firmware behavior)
+- **Unsaved Changes Warning**: Banner alerts you when device has unsaved changes
+- **YAML Generator**: Generate ESPHome sensor configuration for active channels
 - **Multi-phase Support**: Full support for emonPi3 with 3-phase voltage monitoring
+- **Multi-language**: Supports English, French, German, and Italian
 
 ## Requirements
 
@@ -94,22 +103,30 @@ The main configuration interface with:
 - **Load Config**: Read current configuration from the emonPi/Tx (sends `l` command)
 - **Save**: Save configuration to EEPROM (sends `s` command)
 - **Zero Energy Values**: Reset all energy counters (with 20-second confirmation countdown)
+- **Generate YAML**: Generate ESPHome sensor configuration for active channels
+
+**Other features:**
+- **Device selector**: Switch between multiple emonPi/Tx devices (dropdown in status bar)
+- **Unsaved changes warning**: Banner appears when configuration changes haven't been saved
 
 ### Serial Terminal Tab
 
 A full serial terminal for direct communication:
 
-- **Terminal Output**: Shows all received data from the emonPi/Tx
+- **Terminal Output**: Shows all received data from the emonPi/Tx (resizable window)
 - **Command Input**: Type commands to send to the emonPi/Tx
-- **Quick Commands**: Buttons for common commands (l, v, s, d)
+- **Quick Commands**: Buttons for common commands (l, v, s, ?)
+- **Toolbar**: Autoscroll toggle, copy to clipboard, download log, clear terminal
 
 ### Live Data Tab
 
-Real-time display of all sensor values received from the emonPi/Tx, including:
-- Voltage readings (V1-V3, depending on single/three phase)
-- Power readings (P1-P12, depending on device)
-- Energy totals (E1-E12, depending on device)
-- Other sensors: temperature, pulse, message counter (MSG)
+Real-time display of all sensor values received from the emonPi/Tx, grouped by type:
+- **Voltage** (V1-V3, depending on single/three phase)
+- **Power** (P1-P12, depending on device)
+- **Energy** (E1-E12, depending on device)
+- **Other sensors**: temperature, pulse, message counter (MSG)
+
+Inactive channels are displayed with a strikethrough indicator.
 
 ## Common emonPi/Tx Commands
 
@@ -118,6 +135,7 @@ Real-time display of all sensor values received from the emonPi/Tx, including:
 | `l` | List all configuration parameters |
 | `v` | Show firmware version |
 | `s` | Save configuration to EEPROM |
+| `?` | Show help with available commands |
 | `d` | Reset to default values |
 | `z` | Zero energy counters (requires `y` confirmation) |
 | `k<n> <ical> <ilead>` | Set CT channel calibration |

--- a/custom_components/emontx_config/frontend/i18n/de.json
+++ b/custom_components/emontx_config/frontend/i18n/de.json
@@ -75,7 +75,15 @@
     },
     "liveData": {
         "title": "Live Sensordaten",
-        "waiting": "Warte auf Daten vom emonPi/Tx..."
+        "waiting": "Warte auf Daten vom emonPi/Tx...",
+        "groups": {
+            "MSG": "Nachricht",
+            "V": "Spannung",
+            "P": "Leistung",
+            "E": "Energie",
+            "T": "Temperatur",
+            "pulse": "Impuls"
+        }
     },
     "zeroConfirm": {
         "title": "Energie Nullstellen Bestätigen",

--- a/custom_components/emontx_config/frontend/i18n/de.json
+++ b/custom_components/emontx_config/frontend/i18n/de.json
@@ -1,0 +1,93 @@
+{
+    "title": "emonPi/Tx Konfiguration",
+    "subtitle": "Konfigurieren Sie Ihr OpenEnergyMonitor emonPi/Tx Gerät über die ESP32 Serielle Brücke",
+    "haStatus": "Home Assistant",
+    "deviceStatus": "emonPi/Tx",
+    "deviceSelector": "Gerät",
+    "connected": "Verbunden",
+    "disconnected": "Getrennt",
+    "unknown": "Unbekannt",
+    "tabs": {
+        "config": "Gerätekonfiguration",
+        "terminal": "Serielles Terminal",
+        "liveData": "Live-Daten"
+    },
+    "buttons": {
+        "loadConfig": "Konfig Laden",
+        "save": "Änderungen Speichern",
+        "zeroEnergy": "Energie Nullstellen",
+        "resetDefaults": "Auf Standard Zurücksetzen",
+        "reloadConfig": "Konfig Neu Laden",
+        "generateYaml": "YAML Generieren"
+    },
+    "yamlModal": {
+        "title": "ESPHome Sensor YAML",
+        "description": "Kopieren Sie dieses YAML in Ihre ESPHome-Konfiguration, um Sensoren für aktive Kanäle hinzuzufügen:",
+        "copy": "In Zwischenablage",
+        "close": "Schließen",
+        "copied": "Kopiert!"
+    },
+    "config": {
+        "waiting": "Warte auf Konfigurationsdaten...",
+        "clickLoad": "Klicken Sie auf \"Konfig Laden\" um die aktuelle Konfiguration zu lesen.",
+        "firmwareUpdateRequired": "Firmware-Update erforderlich:",
+        "firmwareUpdateMessage": "Es scheint, dass Sie eine ältere Firmware-Version verwenden. Bitte aktualisieren Sie die Geräte-Firmware, um dieses Tool zu nutzen.",
+        "deviceInfo": "Geräteinformationen",
+        "hardware": "Hardware",
+        "hardwareRev": "Revision",
+        "version": "Version",
+        "voltageLabel": "Spannung",
+        "library": "Bibliothek",
+        "voltageCalibration": "Spannungskalibrierung",
+        "calibration": "Kalibrierung",
+        "ctChannels": "CT-Kanäle",
+        "channel": "Kanal",
+        "ctType": "CT-Typ",
+        "phase": "Phase",
+        "vChan1": "V Kanal 1",
+        "vChan2": "V Kanal 2",
+        "power": "Leistung",
+        "energy": "Energie",
+        "voltageChannels": "Spannungskanäle",
+        "active": "Aktiv",
+        "vCal": "V Kal",
+        "radioSettings": "Funk-Einstellungen",
+        "radioEnabled": "Funk Aktiviert",
+        "nodeId": "Knoten-ID",
+        "group": "Gruppe",
+        "frequency": "Frequenz",
+        "format": "Format",
+        "otherSettings": "Weitere Einstellungen",
+        "pulseInput": "Impulseingang",
+        "pulsePeriod": "Impulsperiode",
+        "datalogInterval": "Datalog-Intervall",
+        "serialFormat": "Serielles Format",
+        "keyValuePairs": "Schlüssel:Wert Paare",
+        "fullJson": "Vollständiges JSON"
+    },
+    "terminal": {
+        "title": "Serieller Monitor",
+        "placeholder": "Befehl eingeben...",
+        "send": "Senden",
+        "autoscroll": "Autoscroll",
+        "copy": "Kopieren",
+        "download": "Herunterladen",
+        "clear": "Löschen",
+        "copied": "Kopiert!"
+    },
+    "liveData": {
+        "title": "Live Sensordaten",
+        "waiting": "Warte auf Daten vom emonPi/Tx..."
+    },
+    "zeroConfirm": {
+        "title": "Energie Nullstellen Bestätigen",
+        "message": "Sind Sie sicher, dass Sie alle Energiezähler zurücksetzen möchten?",
+        "warning": "Diese Aktion kann nicht rückgängig gemacht werden.",
+        "confirm": "Ja, Nullstellen",
+        "cancel": "Abbrechen"
+    },
+    "unsavedChanges": {
+        "title": "Ungespeicherte Änderungen!",
+        "message": "Es gibt ungespeicherte Änderungen auf dem Gerät. Verwenden Sie \"Speichern\" um sie zu sichern."
+    }
+}

--- a/custom_components/emontx_config/frontend/i18n/de.json
+++ b/custom_components/emontx_config/frontend/i18n/de.json
@@ -1,8 +1,6 @@
 {
     "title": "emonPi/Tx Konfiguration",
     "subtitle": "Konfigurieren Sie Ihr OpenEnergyMonitor emonPi/Tx Gerät über die ESP32 Serielle Brücke",
-    "haStatus": "Home Assistant",
-    "deviceStatus": "emonPi/Tx",
     "deviceSelector": "Gerät",
     "connected": "Verbunden",
     "disconnected": "Getrennt",

--- a/custom_components/emontx_config/frontend/i18n/en.json
+++ b/custom_components/emontx_config/frontend/i18n/en.json
@@ -1,0 +1,93 @@
+{
+    "title": "emonPi/Tx Configuration",
+    "subtitle": "Configure your OpenEnergyMonitor emonPi/Tx device via ESP32 serial bridge",
+    "haStatus": "Home Assistant",
+    "deviceStatus": "emonPi/Tx",
+    "deviceSelector": "Device",
+    "connected": "Connected",
+    "disconnected": "Disconnected",
+    "unknown": "Unknown",
+    "tabs": {
+        "config": "Device Config",
+        "terminal": "Serial Terminal",
+        "liveData": "Live Data"
+    },
+    "buttons": {
+        "loadConfig": "Load Config",
+        "save": "Save Changes",
+        "zeroEnergy": "Zero Energy Values",
+        "resetDefaults": "Reset to Defaults",
+        "reloadConfig": "Reload Config",
+        "generateYaml": "Generate YAML"
+    },
+    "yamlModal": {
+        "title": "ESPHome Sensor YAML",
+        "description": "Copy this YAML into your ESPHome configuration to add sensors for active channels:",
+        "copy": "Copy to Clipboard",
+        "close": "Close",
+        "copied": "Copied!"
+    },
+    "config": {
+        "waiting": "Waiting for configuration data...",
+        "clickLoad": "Click \"Load Config\" to read the current device configuration.",
+        "firmwareUpdateRequired": "Firmware update required:",
+        "firmwareUpdateMessage": "Looks like you are running an older firmware version. Please upgrade the device firmware to use this tool.",
+        "deviceInfo": "Device Information",
+        "hardware": "Hardware",
+        "hardwareRev": "Revision",
+        "version": "Version",
+        "voltageLabel": "Voltage",
+        "library": "Library",
+        "voltageCalibration": "Voltage Calibration",
+        "calibration": "Calibration",
+        "ctChannels": "CT Channels",
+        "channel": "Channel",
+        "ctType": "CT Type",
+        "phase": "Phase",
+        "vChan1": "V Chan 1",
+        "vChan2": "V Chan 2",
+        "power": "Power",
+        "energy": "Energy",
+        "voltageChannels": "Voltage Channels",
+        "active": "Active",
+        "vCal": "V Cal",
+        "radioSettings": "Radio Settings",
+        "radioEnabled": "Radio Enabled",
+        "nodeId": "Node ID",
+        "group": "Group",
+        "frequency": "Frequency",
+        "format": "Format",
+        "otherSettings": "Other Settings",
+        "pulseInput": "Pulse Input",
+        "pulsePeriod": "Pulse Period",
+        "datalogInterval": "Datalog Interval",
+        "serialFormat": "Serial Format",
+        "keyValuePairs": "Key:value pairs",
+        "fullJson": "Full JSON"
+    },
+    "terminal": {
+        "title": "Serial Monitor",
+        "placeholder": "Enter command...",
+        "send": "Send",
+        "autoscroll": "Autoscroll",
+        "copy": "Copy",
+        "download": "Download",
+        "clear": "Clear",
+        "copied": "Copied!"
+    },
+    "liveData": {
+        "title": "Live Sensor Data",
+        "waiting": "Waiting for data from emonPi/Tx..."
+    },
+    "zeroConfirm": {
+        "title": "Confirm Zero Energy",
+        "message": "Are you sure you want to zero all energy counters?",
+        "warning": "This action cannot be undone.",
+        "confirm": "Yes, Zero Counters",
+        "cancel": "Cancel"
+    },
+    "unsavedChanges": {
+        "title": "Unsaved Changes!",
+        "message": "There are unsaved changes on the device. Use \"Save Changes\" to save them."
+    }
+}

--- a/custom_components/emontx_config/frontend/i18n/en.json
+++ b/custom_components/emontx_config/frontend/i18n/en.json
@@ -75,7 +75,15 @@
     },
     "liveData": {
         "title": "Live Sensor Data",
-        "waiting": "Waiting for data from emonPi/Tx..."
+        "waiting": "Waiting for data from emonPi/Tx...",
+        "groups": {
+            "MSG": "Message",
+            "V": "Voltage",
+            "P": "Power",
+            "E": "Energy",
+            "T": "Temperature",
+            "pulse": "Pulse"
+        }
     },
     "zeroConfirm": {
         "title": "Confirm Zero Energy",

--- a/custom_components/emontx_config/frontend/i18n/en.json
+++ b/custom_components/emontx_config/frontend/i18n/en.json
@@ -1,8 +1,6 @@
 {
     "title": "emonPi/Tx Configuration",
     "subtitle": "Configure your OpenEnergyMonitor emonPi/Tx device via ESP32 serial bridge",
-    "haStatus": "Home Assistant",
-    "deviceStatus": "emonPi/Tx",
     "deviceSelector": "Device",
     "connected": "Connected",
     "disconnected": "Disconnected",

--- a/custom_components/emontx_config/frontend/i18n/fr.json
+++ b/custom_components/emontx_config/frontend/i18n/fr.json
@@ -75,7 +75,15 @@
     },
     "liveData": {
         "title": "Données en Temps Réel",
-        "waiting": "En attente des données de l'emonPi/Tx..."
+        "waiting": "En attente des données de l'emonPi/Tx...",
+        "groups": {
+            "MSG": "Message",
+            "V": "Tension",
+            "P": "Puissance",
+            "E": "Énergie",
+            "T": "Température",
+            "pulse": "Impulsion"
+        }
     },
     "zeroConfirm": {
         "title": "Confirmer la Remise à Zéro",

--- a/custom_components/emontx_config/frontend/i18n/fr.json
+++ b/custom_components/emontx_config/frontend/i18n/fr.json
@@ -1,0 +1,93 @@
+{
+    "title": "Configuration emonPi/Tx",
+    "subtitle": "Configurez votre appareil OpenEnergyMonitor emonPi/Tx via le pont série ESP32",
+    "haStatus": "Home Assistant",
+    "deviceStatus": "emonPi/Tx",
+    "deviceSelector": "Appareil",
+    "connected": "Connecté",
+    "disconnected": "Déconnecté",
+    "unknown": "Inconnu",
+    "tabs": {
+        "config": "Configuration",
+        "terminal": "Terminal Série",
+        "liveData": "Données en Direct"
+    },
+    "buttons": {
+        "loadConfig": "Charger Config",
+        "save": "Enregistrer les Modifications",
+        "zeroEnergy": "Remettre à Zéro",
+        "resetDefaults": "Réinitialiser",
+        "reloadConfig": "Recharger Config",
+        "generateYaml": "Générer YAML"
+    },
+    "yamlModal": {
+        "title": "YAML Capteurs ESPHome",
+        "description": "Copiez ce YAML dans votre configuration ESPHome pour ajouter des capteurs pour les canaux actifs :",
+        "copy": "Copier",
+        "close": "Fermer",
+        "copied": "Copié !"
+    },
+    "config": {
+        "waiting": "En attente des données de configuration...",
+        "clickLoad": "Cliquez sur \"Charger Config\" pour lire la configuration actuelle.",
+        "firmwareUpdateRequired": "Mise à jour du firmware requise :",
+        "firmwareUpdateMessage": "Il semble que vous utilisez une ancienne version du firmware. Veuillez mettre à jour le firmware de l'appareil pour utiliser cet outil.",
+        "deviceInfo": "Informations sur l'Appareil",
+        "hardware": "Matériel",
+        "hardwareRev": "Révision",
+        "version": "Version",
+        "voltageLabel": "Tension",
+        "library": "Bibliothèque",
+        "voltageCalibration": "Calibration de Tension",
+        "calibration": "Calibration",
+        "ctChannels": "Canaux CT",
+        "channel": "Canal",
+        "ctType": "Type CT",
+        "phase": "Phase",
+        "vChan1": "V Canal 1",
+        "vChan2": "V Canal 2",
+        "power": "Puissance",
+        "energy": "Énergie",
+        "voltageChannels": "Canaux de Tension",
+        "active": "Actif",
+        "vCal": "Cal V",
+        "radioSettings": "Paramètres Radio",
+        "radioEnabled": "Radio Activée",
+        "nodeId": "ID Nœud",
+        "group": "Groupe",
+        "frequency": "Fréquence",
+        "format": "Format",
+        "otherSettings": "Autres Paramètres",
+        "pulseInput": "Entrée Impulsion",
+        "pulsePeriod": "Période Impulsion",
+        "datalogInterval": "Intervalle Datalog",
+        "serialFormat": "Format Série",
+        "keyValuePairs": "Paires clé:valeur",
+        "fullJson": "JSON Complet"
+    },
+    "terminal": {
+        "title": "Moniteur Série",
+        "placeholder": "Entrez une commande...",
+        "send": "Envoyer",
+        "autoscroll": "Défilement auto",
+        "copy": "Copier",
+        "download": "Télécharger",
+        "clear": "Effacer",
+        "copied": "Copié !"
+    },
+    "liveData": {
+        "title": "Données en Temps Réel",
+        "waiting": "En attente des données de l'emonPi/Tx..."
+    },
+    "zeroConfirm": {
+        "title": "Confirmer la Remise à Zéro",
+        "message": "Êtes-vous sûr de vouloir remettre à zéro tous les compteurs d'énergie ?",
+        "warning": "Cette action est irréversible.",
+        "confirm": "Oui, Remettre à Zéro",
+        "cancel": "Annuler"
+    },
+    "unsavedChanges": {
+        "title": "Modifications non enregistrées !",
+        "message": "Il y a des modifications non enregistrées sur l'appareil. Utilisez \"Enregistrer\" pour les sauvegarder."
+    }
+}

--- a/custom_components/emontx_config/frontend/i18n/fr.json
+++ b/custom_components/emontx_config/frontend/i18n/fr.json
@@ -1,8 +1,6 @@
 {
     "title": "Configuration emonPi/Tx",
     "subtitle": "Configurez votre appareil OpenEnergyMonitor emonPi/Tx via le pont série ESP32",
-    "haStatus": "Home Assistant",
-    "deviceStatus": "emonPi/Tx",
     "deviceSelector": "Appareil",
     "connected": "Connecté",
     "disconnected": "Déconnecté",

--- a/custom_components/emontx_config/frontend/i18n/it.json
+++ b/custom_components/emontx_config/frontend/i18n/it.json
@@ -1,0 +1,99 @@
+{
+    "title": "Configurazione emonPi/Tx",
+    "subtitle": "Configura il tuo dispositivo OpenEnergyMonitor emonPi/Tx tramite bridge seriale ESP32",
+    "deviceSelector": "Dispositivo",
+    "connected": "Connesso",
+    "disconnected": "Disconnesso",
+    "unknown": "Sconosciuto",
+    "tabs": {
+        "config": "Configurazione",
+        "terminal": "Terminale Seriale",
+        "liveData": "Dati in Tempo Reale"
+    },
+    "buttons": {
+        "loadConfig": "Carica Config",
+        "save": "Salva Modifiche",
+        "zeroEnergy": "Azzera Energia",
+        "resetDefaults": "Ripristina Predefiniti",
+        "reloadConfig": "Ricarica Config",
+        "generateYaml": "Genera YAML"
+    },
+    "yamlModal": {
+        "title": "YAML Sensori ESPHome",
+        "description": "Copia questo YAML nella tua configurazione ESPHome per aggiungere sensori per i canali attivi:",
+        "copy": "Copia",
+        "close": "Chiudi",
+        "copied": "Copiato!"
+    },
+    "config": {
+        "waiting": "In attesa dei dati di configurazione...",
+        "clickLoad": "Clicca \"Carica Config\" per leggere la configurazione attuale.",
+        "firmwareUpdateRequired": "Aggiornamento firmware richiesto:",
+        "firmwareUpdateMessage": "Sembra che tu stia usando una versione firmware obsoleta. Aggiorna il firmware del dispositivo per usare questo strumento.",
+        "deviceInfo": "Informazioni Dispositivo",
+        "hardware": "Hardware",
+        "hardwareRev": "Revisione",
+        "version": "Versione",
+        "voltageLabel": "Tensione",
+        "library": "Libreria",
+        "voltageCalibration": "Calibrazione Tensione",
+        "calibration": "Calibrazione",
+        "ctChannels": "Canali CT",
+        "channel": "Canale",
+        "ctType": "Tipo CT",
+        "phase": "Fase",
+        "vChan1": "V Canale 1",
+        "vChan2": "V Canale 2",
+        "power": "Potenza",
+        "energy": "Energia",
+        "voltageChannels": "Canali Tensione",
+        "active": "Attivo",
+        "vCal": "Cal V",
+        "radioSettings": "Impostazioni Radio",
+        "radioEnabled": "Radio Attiva",
+        "nodeId": "ID Nodo",
+        "group": "Gruppo",
+        "frequency": "Frequenza",
+        "format": "Formato",
+        "otherSettings": "Altre Impostazioni",
+        "pulseInput": "Ingresso Impulsi",
+        "pulsePeriod": "Periodo Impulsi",
+        "datalogInterval": "Intervallo Datalog",
+        "serialFormat": "Formato Seriale",
+        "keyValuePairs": "Coppie chiave:valore",
+        "fullJson": "JSON Completo"
+    },
+    "terminal": {
+        "title": "Monitor Seriale",
+        "placeholder": "Inserisci comando...",
+        "send": "Invia",
+        "autoscroll": "Scorrimento auto",
+        "copy": "Copia",
+        "download": "Scarica",
+        "clear": "Cancella",
+        "copied": "Copiato!"
+    },
+    "liveData": {
+        "title": "Dati Sensori in Tempo Reale",
+        "waiting": "In attesa dei dati da emonPi/Tx...",
+        "groups": {
+            "MSG": "Messaggio",
+            "V": "Tensione",
+            "P": "Potenza",
+            "E": "Energia",
+            "T": "Temperatura",
+            "pulse": "Impulso"
+        }
+    },
+    "zeroConfirm": {
+        "title": "Conferma Azzeramento Energia",
+        "message": "Sei sicuro di voler azzerare tutti i contatori di energia?",
+        "warning": "Questa azione non può essere annullata.",
+        "confirm": "Sì, Azzera Contatori",
+        "cancel": "Annulla"
+    },
+    "unsavedChanges": {
+        "title": "Modifiche non salvate!",
+        "message": "Ci sono modifiche non salvate sul dispositivo. Usa \"Salva Modifiche\" per salvarle."
+    }
+}

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -695,7 +695,7 @@
                             const hassObj = window.parent.document.querySelector('home-assistant');
                             if (hassObj && hassObj.hass && hassObj.hass.language) {
                                 const haLang = hassObj.hass.language.split('-')[0]; // Get 'fr' from 'fr-FR'
-                                if (['en', 'fr', 'de'].includes(haLang)) {
+                                if (['en', 'fr', 'de', 'it'].includes(haLang)) {
                                     detectedLang = haLang;
                                     console.log('Detected language:', haLang);
                                 }

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -13,7 +13,7 @@
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
             background-color: #f5f5f5;
         }
-        .container { max-width: 1200px; margin: 0 auto; }
+        .container { margin: 0 auto; }
         .header {
             background: linear-gradient(135deg, #4CAF50 0%, #45a049 100%);
             color: white;

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -1417,13 +1417,21 @@
                 },
 
                 isChannelInactive(key) {
-                    // Check if this key corresponds to an inactive CT channel
+                    // Check if this key corresponds to an inactive channel
                     // Keys like P1, P2, E1, E2, etc. map to ichannels[0], ichannels[1], etc.
-                    const match = key.match(/^[PE](\d+)$/);
-                    if (match) {
-                        const channelNum = parseInt(match[1]) - 1; // Convert to 0-based index
+                    const ctMatch = key.match(/^[PE](\d+)$/);
+                    if (ctMatch) {
+                        const channelNum = parseInt(ctMatch[1]) - 1; // Convert to 0-based index
                         if (channelNum >= 0 && channelNum < this.device.ichannels.length) {
                             return this.device.ichannels[channelNum].active === false;
+                        }
+                    }
+                    // Keys like V1, V2, V3 map to vchannels[0], vchannels[1], etc.
+                    const vMatch = key.match(/^V(\d+)$/);
+                    if (vMatch) {
+                        const channelNum = parseInt(vMatch[1]) - 1; // Convert to 0-based index
+                        if (channelNum >= 0 && channelNum < this.device.vchannels.length) {
+                            return this.device.vchannels[channelNum].active === false;
                         }
                     }
                     return false;

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -603,289 +603,10 @@
                 hasUnsavedChanges: false,
                 // Terminal
                 terminalAutoscroll: true,
-                // i18n
+                // i18n - translations loaded from external JSON files
                 lang: 'en',
-                translations: {
-                    en: {
-                        title: 'emonPi/Tx Configuration',
-                        subtitle: 'Configure your OpenEnergyMonitor emonPi/Tx device via ESP32 serial bridge',
-                        haStatus: 'Home Assistant',
-                        deviceStatus: 'emonPi/Tx',
-                        deviceSelector: 'Device',
-                        connected: 'Connected',
-                        disconnected: 'Disconnected',
-                        unknown: 'Unknown',
-                        tabs: {
-                            config: 'Device Config',
-                            terminal: 'Serial Terminal',
-                            liveData: 'Live Data'
-                        },
-                        buttons: {
-                            loadConfig: 'Load Config',
-                            save: 'Save Changes',
-                            zeroEnergy: 'Zero Energy Values',
-                            resetDefaults: 'Reset to Defaults',
-                            reloadConfig: 'Reload Config',
-                            generateYaml: 'Generate YAML'
-                        },
-                        yamlModal: {
-                            title: 'ESPHome Sensor YAML',
-                            description: 'Copy this YAML into your ESPHome configuration to add sensors for active channels:',
-                            copy: 'Copy to Clipboard',
-                            close: 'Close',
-                            copied: 'Copied!'
-                        },
-                        config: {
-                            waiting: 'Waiting for configuration data...',
-                            clickLoad: 'Click "Load Config" to read the current device configuration.',
-                            firmwareUpdateRequired: 'Firmware update required:',
-                            firmwareUpdateMessage: 'Looks like you are running an older firmware version. Please upgrade the device firmware to use this tool.',
-                            deviceInfo: 'Device Information',
-                            hardware: 'Hardware',
-                            hardwareRev: 'Revision',
-                            version: 'Version',
-                            voltageLabel: 'Voltage',
-                            library: 'Library',
-                            voltageCalibration: 'Voltage Calibration',
-                            calibration: 'Calibration',
-                            ctChannels: 'CT Channels',
-                            channel: 'Channel',
-                            ctType: 'CT Type',
-                            phase: 'Phase',
-                            vChan1: 'V Chan 1',
-                            vChan2: 'V Chan 2',
-                            power: 'Power',
-                            energy: 'Energy',
-                            voltageChannels: 'Voltage Channels',
-                            active: 'Active',
-                            vCal: 'V Cal',
-                            radioSettings: 'Radio Settings',
-                            radioEnabled: 'Radio Enabled',
-                            nodeId: 'Node ID',
-                            group: 'Group',
-                            frequency: 'Frequency',
-                            format: 'Format',
-                            otherSettings: 'Other Settings',
-                            pulseInput: 'Pulse Input',
-                            pulsePeriod: 'Pulse Period',
-                            datalogInterval: 'Datalog Interval',
-                            serialFormat: 'Serial Format',
-                            keyValuePairs: 'Key:value pairs',
-                            fullJson: 'Full JSON'
-                        },
-                        terminal: {
-                            title: 'Serial Monitor',
-                            placeholder: 'Enter command...',
-                            send: 'Send',
-                            autoscroll: 'Autoscroll',
-                            copy: 'Copy',
-                            download: 'Download',
-                            clear: 'Clear',
-                            copied: 'Copied!'
-                        },
-                        liveData: {
-                            title: 'Live Sensor Data',
-                            waiting: 'Waiting for data from emonPi/Tx...'
-                        },
-                        zeroConfirm: {
-                            title: 'Confirm Zero Energy',
-                            message: 'Are you sure you want to zero all energy counters?',
-                            warning: 'This action cannot be undone.',
-                            confirm: 'Yes, Zero Counters',
-                            cancel: 'Cancel'
-                        },
-                        unsavedChanges: {
-                            title: 'Unsaved Changes!',
-                            message: 'There are unsaved changes on the device. Use "Save Changes" to save them.'
-                        }
-                    },
-                    fr: {
-                        title: 'Configuration emonPi/Tx',
-                        subtitle: 'Configurez votre appareil OpenEnergyMonitor emonPi/Tx via le pont série ESP32',
-                        haStatus: 'Home Assistant',
-                        deviceStatus: 'emonPi/Tx',
-                        deviceSelector: 'Appareil',
-                        connected: 'Connecté',
-                        disconnected: 'Déconnecté',
-                        unknown: 'Inconnu',
-                        tabs: {
-                            config: 'Configuration',
-                            terminal: 'Terminal Série',
-                            liveData: 'Données en Direct'
-                        },
-                        buttons: {
-                            loadConfig: 'Charger Config',
-                            save: 'Enregistrer les Modifications',
-                            zeroEnergy: 'Remettre à Zéro',
-                            resetDefaults: 'Réinitialiser',
-                            reloadConfig: 'Recharger Config',
-                            generateYaml: 'Générer YAML'
-                        },
-                        yamlModal: {
-                            title: 'YAML Capteurs ESPHome',
-                            description: 'Copiez ce YAML dans votre configuration ESPHome pour ajouter des capteurs pour les canaux actifs :',
-                            copy: 'Copier',
-                            close: 'Fermer',
-                            copied: 'Copié !'
-                        },
-                        config: {
-                            waiting: 'En attente des données de configuration...',
-                            clickLoad: 'Cliquez sur "Charger Config" pour lire la configuration actuelle.',
-                            firmwareUpdateRequired: 'Mise à jour du firmware requise :',
-                            firmwareUpdateMessage: 'Il semble que vous utilisez une ancienne version du firmware. Veuillez mettre à jour le firmware de l\'appareil pour utiliser cet outil.',
-                            deviceInfo: 'Informations sur l\'Appareil',
-                            hardware: 'Matériel',
-                            hardwareRev: 'Révision',
-                            version: 'Version',
-                            voltageLabel: 'Tension',
-                            library: 'Bibliothèque',
-                            voltageCalibration: 'Calibration de Tension',
-                            calibration: 'Calibration',
-                            ctChannels: 'Canaux CT',
-                            channel: 'Canal',
-                            ctType: 'Type CT',
-                            phase: 'Phase',
-                            vChan1: 'V Canal 1',
-                            vChan2: 'V Canal 2',
-                            power: 'Puissance',
-                            energy: 'Énergie',
-                            voltageChannels: 'Canaux de Tension',
-                            active: 'Actif',
-                            vCal: 'Cal V',
-                            radioSettings: 'Paramètres Radio',
-                            radioEnabled: 'Radio Activée',
-                            nodeId: 'ID Nœud',
-                            group: 'Groupe',
-                            frequency: 'Fréquence',
-                            format: 'Format',
-                            otherSettings: 'Autres Paramètres',
-                            pulseInput: 'Entrée Impulsion',
-                            pulsePeriod: 'Période Impulsion',
-                            datalogInterval: 'Intervalle Datalog',
-                            serialFormat: 'Format Série',
-                            keyValuePairs: 'Paires clé:valeur',
-                            fullJson: 'JSON Complet'
-                        },
-                        terminal: {
-                            title: 'Moniteur Série',
-                            placeholder: 'Entrez une commande...',
-                            send: 'Envoyer',
-                            autoscroll: 'Défilement auto',
-                            copy: 'Copier',
-                            download: 'Télécharger',
-                            clear: 'Effacer',
-                            copied: 'Copié !'
-                        },
-                        liveData: {
-                            title: 'Données en Temps Réel',
-                            waiting: 'En attente des données de l\'emonPi/Tx...'
-                        },
-                        zeroConfirm: {
-                            title: 'Confirmer la Remise à Zéro',
-                            message: 'Êtes-vous sûr de vouloir remettre à zéro tous les compteurs d\'énergie ?',
-                            warning: 'Cette action est irréversible.',
-                            confirm: 'Oui, Remettre à Zéro',
-                            cancel: 'Annuler'
-                        },
-                        unsavedChanges: {
-                            title: 'Modifications non enregistrées !',
-                            message: 'Il y a des modifications non enregistrées sur l\'appareil. Utilisez "Enregistrer" pour les sauvegarder.'
-                        }
-                    },
-                    de: {
-                        title: 'emonPi/Tx Konfiguration',
-                        subtitle: 'Konfigurieren Sie Ihr OpenEnergyMonitor emonPi/Tx Gerät über die ESP32 Serielle Brücke',
-                        haStatus: 'Home Assistant',
-                        deviceStatus: 'emonPi/Tx',
-                        deviceSelector: 'Gerät',
-                        connected: 'Verbunden',
-                        disconnected: 'Getrennt',
-                        unknown: 'Unbekannt',
-                        tabs: {
-                            config: 'Gerätekonfiguration',
-                            terminal: 'Serielles Terminal',
-                            liveData: 'Live-Daten'
-                        },
-                        buttons: {
-                            loadConfig: 'Konfig Laden',
-                            save: 'Änderungen Speichern',
-                            zeroEnergy: 'Energie Nullstellen',
-                            resetDefaults: 'Auf Standard Zurücksetzen',
-                            reloadConfig: 'Konfig Neu Laden',
-                            generateYaml: 'YAML Generieren'
-                        },
-                        yamlModal: {
-                            title: 'ESPHome Sensor YAML',
-                            description: 'Kopieren Sie dieses YAML in Ihre ESPHome-Konfiguration, um Sensoren für aktive Kanäle hinzuzufügen:',
-                            copy: 'In Zwischenablage',
-                            close: 'Schließen',
-                            copied: 'Kopiert!'
-                        },
-                        config: {
-                            waiting: 'Warte auf Konfigurationsdaten...',
-                            clickLoad: 'Klicken Sie auf "Konfig Laden" um die aktuelle Konfiguration zu lesen.',
-                            firmwareUpdateRequired: 'Firmware-Update erforderlich:',
-                            firmwareUpdateMessage: 'Es scheint, dass Sie eine ältere Firmware-Version verwenden. Bitte aktualisieren Sie die Geräte-Firmware, um dieses Tool zu nutzen.',
-                            deviceInfo: 'Geräteinformationen',
-                            hardware: 'Hardware',
-                            hardwareRev: 'Revision',
-                            version: 'Version',
-                            voltageLabel: 'Spannung',
-                            library: 'Bibliothek',
-                            voltageCalibration: 'Spannungskalibrierung',
-                            calibration: 'Kalibrierung',
-                            ctChannels: 'CT-Kanäle',
-                            channel: 'Kanal',
-                            ctType: 'CT-Typ',
-                            phase: 'Phase',
-                            vChan1: 'V Kanal 1',
-                            vChan2: 'V Kanal 2',
-                            power: 'Leistung',
-                            energy: 'Energie',
-                            voltageChannels: 'Spannungskanäle',
-                            active: 'Aktiv',
-                            vCal: 'V Kal',
-                            radioSettings: 'Funk-Einstellungen',
-                            radioEnabled: 'Funk Aktiviert',
-                            nodeId: 'Knoten-ID',
-                            group: 'Gruppe',
-                            frequency: 'Frequenz',
-                            format: 'Format',
-                            otherSettings: 'Weitere Einstellungen',
-                            pulseInput: 'Impulseingang',
-                            pulsePeriod: 'Impulsperiode',
-                            datalogInterval: 'Datalog-Intervall',
-                            serialFormat: 'Serielles Format',
-                            keyValuePairs: 'Schlüssel:Wert Paare',
-                            fullJson: 'Vollständiges JSON'
-                        },
-                        terminal: {
-                            title: 'Serieller Monitor',
-                            placeholder: 'Befehl eingeben...',
-                            send: 'Senden',
-                            autoscroll: 'Autoscroll',
-                            copy: 'Kopieren',
-                            download: 'Herunterladen',
-                            clear: 'Löschen',
-                            copied: 'Kopiert!'
-                        },
-                        liveData: {
-                            title: 'Live Sensordaten',
-                            waiting: 'Warte auf Daten vom emonPi/Tx...'
-                        },
-                        zeroConfirm: {
-                            title: 'Energie Nullstellen Bestätigen',
-                            message: 'Sind Sie sicher, dass Sie alle Energiezähler zurücksetzen möchten?',
-                            warning: 'Diese Aktion kann nicht rückgängig gemacht werden.',
-                            confirm: 'Ja, Nullstellen',
-                            cancel: 'Abbrechen'
-                        },
-                        unsavedChanges: {
-                            title: 'Ungespeicherte Änderungen!',
-                            message: 'Es gibt ungespeicherte Änderungen auf dem Gerät. Verwenden Sie "Speichern" um sie zu sichern.'
-                        }
-                    }
-                },
+                translations: {},
+                translationsLoaded: false,
                 device: {
                     firmware: '',
                     firmware_version: '',
@@ -919,7 +640,7 @@
             },
             computed: {
                 t() {
-                    return this.translations[this.lang] || this.translations.en;
+                    return this.translations[this.lang] || this.translations.en || {};
                 }
             },
             mounted() {
@@ -929,21 +650,56 @@
                 this.initHassConnection();
             },
             methods: {
-                detectLanguage() {
+                async detectLanguage() {
                     // Try to get language from Home Assistant
+                    let detectedLang = 'en';
                     try {
                         if (window.parent && window.parent.document) {
                             const hassObj = window.parent.document.querySelector('home-assistant');
                             if (hassObj && hassObj.hass && hassObj.hass.language) {
                                 const haLang = hassObj.hass.language.split('-')[0]; // Get 'fr' from 'fr-FR'
-                                if (this.translations[haLang]) {
-                                    this.lang = haLang;
+                                if (['en', 'fr', 'de'].includes(haLang)) {
+                                    detectedLang = haLang;
                                     console.log('Detected language:', haLang);
                                 }
                             }
                         }
                     } catch (e) {
                         console.log('Could not detect HA language, using default');
+                    }
+
+                    // Load translations for detected language and English (fallback)
+                    await this.loadTranslations(detectedLang);
+                },
+
+                async loadTranslations(lang) {
+                    // Get the base path from the current page URL
+                    const currentPath = window.location.pathname;
+                    const basePath = currentPath.substring(0, currentPath.lastIndexOf('/'));
+
+                    try {
+                        // Always load English as fallback
+                        const enResponse = await fetch(`${basePath}/i18n/en.json`);
+                        if (enResponse.ok) {
+                            this.$set(this.translations, 'en', await enResponse.json());
+                        }
+
+                        // Load requested language if different from English
+                        if (lang !== 'en') {
+                            const langResponse = await fetch(`${basePath}/i18n/${lang}.json`);
+                            if (langResponse.ok) {
+                                this.$set(this.translations, lang, await langResponse.json());
+                                this.lang = lang;
+                            }
+                        }
+
+                        this.translationsLoaded = true;
+                        console.log('Translations loaded for:', Object.keys(this.translations).join(', '));
+                    } catch (e) {
+                        console.error('Failed to load translations:', e);
+                        // Fallback: use inline minimal translations
+                        this.$set(this.translations, 'en', { title: 'emonPi/Tx Configuration', subtitle: 'Loading...' });
+                        this.translationsLoaded = true;
                     }
                 },
 

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -539,7 +539,7 @@
                     </div>
                     <div v-else>
                         <div v-for="(items, group) in groupedLiveData" :key="group" style="margin-bottom: 15px;">
-                            <h4 style="margin: 0 0 8px 0; color: #666; font-size: 14px;">{{ t.liveData.groups && t.liveData.groups[group] ? t.liveData.groups[group] : group }}</h4>
+                            <h4 style="margin: 0 0 8px 0; color: #666; font-size: 14px;">{{ getGroupLabel(group) }}</h4>
                             <div class="config-grid">
                                 <div :class="['config-item', isChannelInactive(key) ? 'inactive' : '']" v-for="(value, key) in items" :key="key">
                                     <label>{{ key }}</label>
@@ -1414,6 +1414,25 @@
                     if (terminal) {
                         terminal.innerHTML = '';
                     }
+                },
+
+                getGroupLabel(group) {
+                    // Case-insensitive lookup for group labels
+                    if (this.t.liveData && this.t.liveData.groups) {
+                        // Try exact match first
+                        if (this.t.liveData.groups[group]) {
+                            return this.t.liveData.groups[group];
+                        }
+                        // Try uppercase
+                        if (this.t.liveData.groups[group.toUpperCase()]) {
+                            return this.t.liveData.groups[group.toUpperCase()];
+                        }
+                        // Try lowercase
+                        if (this.t.liveData.groups[group.toLowerCase()]) {
+                            return this.t.liveData.groups[group.toLowerCase()];
+                        }
+                    }
+                    return group;
                 },
 
                 isChannelInactive(key) {

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -537,10 +537,15 @@
                     <div v-if="Object.keys(liveData).length === 0" class="alert alert-info">
                         {{ t.liveData.waiting }}
                     </div>
-                    <div v-else class="config-grid">
-                        <div :class="['config-item', isChannelInactive(key) ? 'inactive' : '']" v-for="(value, key) in liveData" :key="key">
-                            <label>{{ key }}</label>
-                            <div class="value">{{ value }}</div>
+                    <div v-else>
+                        <div v-for="(items, group) in groupedLiveData" :key="group" style="margin-bottom: 15px;">
+                            <h4 style="margin: 0 0 8px 0; color: #666; font-size: 14px; text-transform: uppercase;">{{ group }}</h4>
+                            <div class="config-grid">
+                                <div :class="['config-item', isChannelInactive(key) ? 'inactive' : '']" v-for="(value, key) in items" :key="key">
+                                    <label>{{ key }}</label>
+                                    <div class="value">{{ value }}</div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -641,6 +646,38 @@
             computed: {
                 t() {
                     return this.translations[this.lang] || this.translations.en || {};
+                },
+                groupedLiveData() {
+                    // Group live data by prefix (V, P, E, etc.)
+                    const groups = {};
+                    const order = ['MSG', 'V', 'P', 'E', 'T', 'pulse']; // Define display order
+
+                    for (const key in this.liveData) {
+                        // Extract prefix (letters at start of key)
+                        const match = key.match(/^([A-Za-z]+)/);
+                        const prefix = match ? match[1] : 'Other';
+
+                        if (!groups[prefix]) {
+                            groups[prefix] = {};
+                        }
+                        groups[prefix][key] = this.liveData[key];
+                    }
+
+                    // Sort groups by defined order
+                    const sortedGroups = {};
+                    for (const prefix of order) {
+                        if (groups[prefix]) {
+                            sortedGroups[prefix] = groups[prefix];
+                        }
+                    }
+                    // Add any remaining groups not in order
+                    for (const prefix in groups) {
+                        if (!sortedGroups[prefix]) {
+                            sortedGroups[prefix] = groups[prefix];
+                        }
+                    }
+
+                    return sortedGroups;
                 }
             },
             mounted() {

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -280,11 +280,11 @@
         <div class="status-bar">
             <div class="status-item">
                 <div :class="['status-dot', wsConnected ? 'connected' : 'disconnected']"></div>
-                <span>{{ t.haStatus }}: <strong>{{ wsConnected ? t.connected : t.disconnected }}</strong></span>
+                <span>Home Assistant: <strong>{{ wsConnected ? t.connected : t.disconnected }}</strong></span>
             </div>
             <div class="status-item">
                 <div :class="['status-dot', emontxConnected ? 'connected' : 'disconnected']"></div>
-                <span>{{ t.deviceStatus }}: <strong>{{ emontxConnected ? t.connected : t.unknown }}</strong></span>
+                <span>emonPi/Tx: <strong>{{ emontxConnected ? t.connected : t.unknown }}</strong></span>
             </div>
             <div class="status-item" style="margin-left: auto;">
                 <label style="margin-right: 8px;">{{ t.deviceSelector }}:</label>

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -539,7 +539,7 @@
                     </div>
                     <div v-else>
                         <div v-for="(items, group) in groupedLiveData" :key="group" style="margin-bottom: 15px;">
-                            <h4 style="margin: 0 0 8px 0; color: #666; font-size: 14px; text-transform: uppercase;">{{ group }}</h4>
+                            <h4 style="margin: 0 0 8px 0; color: #666; font-size: 14px;">{{ t.liveData.groups && t.liveData.groups[group] ? t.liveData.groups[group] : group }}</h4>
                             <div class="config-grid">
                                 <div :class="['config-item', isChannelInactive(key) ? 'inactive' : '']" v-for="(value, key) in items" :key="key">
                                     <label>{{ key }}</label>

--- a/custom_components/emontx_config/frontend/panel.html
+++ b/custom_components/emontx_config/frontend/panel.html
@@ -1189,21 +1189,21 @@
                     this.writeToStream('l');
                 },
                 setVcal() {
-                    this.writeToStream('k0 ' + parseFloat(this.device.vcal).toFixed(3) + ' 0');
+                    this.writeToStream('k0 ' + parseFloat(this.device.vcal).toFixed(2) + ' 0');
                     this.changes = true;
                     this.hasUnsavedChanges = true;
                 },
                 setVchannel(i) {
                     const active = this.device.vchannels[i].active ? 1 : 0;
-                    const vcal = parseFloat(this.device.vchannels[i].vcal).toFixed(3);
+                    const vcal = parseFloat(this.device.vchannels[i].vcal).toFixed(2);
                     this.writeToStream('k' + (i + 1) + ' ' + active + ' ' + vcal);
                     this.changes = true;
                     this.hasUnsavedChanges = true;
                 },
                 setIcal(i) {
                     console.log('setIcal called for channel', i, 'ical=', this.device.ichannels[i].ical, 'ilead=', this.device.ichannels[i].ilead);
-                    const ical = parseFloat(this.device.ichannels[i].ical).toFixed(3);
-                    const ilead = parseFloat(this.device.ichannels[i].ilead || 0).toFixed(3);
+                    const ical = parseFloat(this.device.ichannels[i].ical).toFixed(2);
+                    const ilead = parseFloat(this.device.ichannels[i].ilead || 0).toFixed(2);
                     console.log('Sending: ical=', ical, 'ilead=', ilead);
                     if (this.device.hardware === 'emonPi3') {
                         const active = this.device.ichannels[i].active ? 1 : 0;


### PR DESCRIPTION
## Summary

- **i18n refactoring**: Extract all translations from inline JavaScript to separate JSON files (`i18n/en.json`, `fr.json`, `de.json`, `it.json`)
- **Add Italian translation**: New language support for Italian users
- **Live Data improvements**: Group sensor data by type (Voltage, Power, Energy, Temperature, Pulse) with translated labels
- **Bug fixes**:
  - Fix inactive channel detection for voltage channels (V1, V2, V3)
  - Fix case-insensitive group label lookup for Live Data
  - Change float precision from 3 to 2 decimals in commands
- **UI improvements**: Remove max-width constraint for better use of screen space
- **README updates**: Document all new features (multi-device, YAML generator, unsaved changes warning, multi-language support)

## Test plan

- [x] Verify panel loads correctly in Home Assistant
- [x] Test language detection (EN, FR, DE, IT)
- [x] Verify Live Data tab shows grouped sensors with correct labels
- [x] Test inactive channel strikethrough for both CT and voltage channels
- [x] Verify configuration commands send correct decimal precision
- [x] Test on different screen sizes (container should use full width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)